### PR TITLE
Follow redirects

### DIFF
--- a/lib/rubot/web_resource.rb
+++ b/lib/rubot/web_resource.rb
@@ -10,9 +10,18 @@ module Rubot
       end
     end
 
-    def self.get_url(url, params = {})
+    def self.get_url(url, params = {}, follow = false)
       query = "?" + params.map { |k,v| "#{k}=#{CGI.escape(v)}" }.join("&") if params.any?
-      Nokogiri::HTML.parse Net::HTTP.get(URI.parse(url + query.to_s))
+      found = false
+      until found
+        res = Net::HTTP.get_response(URI.parse(url + query.to_s))
+        res.header['location'] && follow = true ? url = res.header['location'] : found = true
+      end
+      Nokogiri::HTML.parse Net::HTTP.get(res.body)
+    end
+
+    def self.get_url_follow(url, params={})
+      get_url(url, params, follow = true)
     end
   end
 end

--- a/lib/rubot/web_resource.rb
+++ b/lib/rubot/web_resource.rb
@@ -15,7 +15,7 @@ module Rubot
       found = false
       until found
         res = Net::HTTP.get_response(URI.parse(url + query.to_s))
-        res.header['location'] && follow = true ? url = res.header['location'] : found = true
+        res.header['location'] && follow == true ? url = res.header['location'] : found = true
       end
       Nokogiri::HTML.parse Net::HTTP.get(res.body)
     end


### PR DESCRIPTION
Added optional follow argument to get_url and get_url_follow method wrapper so that pages (most notably title requests) can be made to follow redirects and not just dump 302 Page moved into the channel. 
