### PR TITLE
run an eventmachine tcp server and handle callbacks

### DIFF
--- a/bin/rubot
+++ b/bin/rubot
@@ -20,7 +20,7 @@ if ARGV[0] == "server"
         $conn = EventMachine::connect(config[:server], config[:port], Rubot::Server, dispatcher, config)
       end
 
-      EventMachine.start_server "127.0.0.1", 8081, Rubot::CallbackHandler
+      EventMachine.start_server "0.0.0.0", 8081, Rubot::CallbackHandler
     end
    rescue Interrupt
      dispatcher.quit

--- a/bin/rubot
+++ b/bin/rubot
@@ -9,16 +9,18 @@ require "yaml"
 if ARGV[0] == "server"
   config = YAML.load_file("#{Dir.pwd}/config.yml").inject({}) { |h,p| h[p[0].intern] = p[1]; h }
   config[:port] ||= 6667
-  
+
   dispatcher = Rubot::Dispatcher.new(Dir.pwd, config)
 
   begin
     EventMachine::run do
       if config[:host]
-        EventMachine::bind_connect(config[:host], nil, config[:server], config[:port], Rubot::Server, dispatcher, config)
+        $conn = EventMachine::bind_connect(config[:host], nil, config[:server], config[:port], Rubot::Server, dispatcher, config)
       else
-        EventMachine::connect(config[:server], config[:port], Rubot::Server, dispatcher, config)
+        $conn = EventMachine::connect(config[:server], config[:port], Rubot::Server, dispatcher, config)
       end
+
+      EventMachine.start_server "127.0.0.1", 8081, Rubot::CallbackHandler
     end
    rescue Interrupt
      dispatcher.quit

--- a/lib/rubot.rb
+++ b/lib/rubot.rb
@@ -9,4 +9,5 @@ module Rubot
   require "rubot/dispatcher"
   require "rubot/message"
   require "rubot/web_resource"
+  require "rubot/callback_handler"
 end

--- a/lib/rubot/callback_handler.rb
+++ b/lib/rubot/callback_handler.rb
@@ -1,0 +1,15 @@
+module Rubot
+  module CallbackHandler
+    def receive_data(data)
+      begin
+        callback = JSON.parse(data)
+
+        callback['channels'].each do |channel|
+          $conn.message channel, callback['message']
+        end
+      rescue
+        puts "invalid callback format: #{data}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are a few instances in which I've been polling when a callback would be a much better solution. I've added `Rubot::CallbackHandler` into rubot which uses a global variable to send a message to the specified channels. The callback format is simple:

``` json
{
  "channels": ["#list", "#of", "#channels"],
  "message": "the message to send to the channels."
}
```
